### PR TITLE
make shell bash

### DIFF
--- a/wclatex.sh
+++ b/wclatex.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ARG="${1:-$PWD}"
 
 if [[ -d "$ARG" ]]; then


### PR DESCRIPTION
#!/bin/sh does not work in dash due to the `if [[` statement (despite dash being POSIX-compliant).

This works in bash, so it should be a bash script.